### PR TITLE
Quote formatting

### DIFF
--- a/forum_spy.py
+++ b/forum_spy.py
@@ -81,7 +81,7 @@ def _convert_formatting(content, max_length, nesting):
                 if child.string != "\n":
                     text_length += len(child.string)
             # Skip children that are block spoilers
-            elif "spoiler_container" in child["class"]:
+            elif child.has_attr("class") and "spoiler_container" in child["class"]:
                 continue
             # Add non-string children's length recursively
             elif child is not node:

--- a/forum_spy.py
+++ b/forum_spy.py
@@ -29,6 +29,13 @@ FORUM_PREVIEW_LENGTH = 250
 FORUM_COLOR_EVEN = int(0x010b17)
 FORUM_COLOR_ODD = int(0x001228)
 
+# What to display when we can't fit a quote?
+SNIP_TEXT = "*[...]*"
+# What to display when we cut off some text?
+TRUNCATE_TEXT = "..."
+# Minimum length of a quote before we 'snip for length'?
+MIN_QUOTE_LENGTH = 5
+
 
 # # # # #
 # Helper functions
@@ -51,23 +58,103 @@ def _get_username(user_profile):
     member = soup.find('a', {'class': 'member'})
     return member.string
 
-def _convert_formatting(content):
+def _convert_formatting(content, max_length):
     # Handle blockquotes and spoiler blocks
-    if not hasattr(content, 'find_all'):
-        return content
 
     # Blockquotes: recursively formats inner quote content the same way
+    # We want to only show quotes if we have enough room after truncation
+    # (i.e. we don't want to have the preview be just quotes.)
+    # So we see how much space should be devoted to non-quote text and
+    # then divide up remaining space among quotes which will get shortened.
+    # (unless the remaining size per quote is very short or zero in which
+    #  case we'll just replace the quote with '[...]')
+
+    # Determine how much non-quote text is here
+    def rec_textlength(node):
+        text_length = 0
+        for child in node.children:
+            # Skip children that are blockquotes
+            if child.name and child.name == 'blockquote':
+                continue
+            # Count length of string nodes
+            elif child.string:
+                if child.string != "\n":
+                    text_length += len(child.string)
+            # Add non-string children's length recursively
+            elif child is not node:
+                text_length += rec_textlength(child)
+        return text_length
+
+    text_length = rec_textlength(content)
+
+    # If we have any blockquotes, we want to format/truncate them recursively
     blockquotes = content.find_all('blockquote', recursive=False)
-    for quote in blockquotes:
-        quote_by = quote.find('div', {'class': 'citey'})
-        quote_content = quote.find('div', {'class': 'quotey'})
-        # Recursively format inner quote text
-        # (base case is no quotes in which case this loop doesn't run)
-        _convert_formatting(quote_content)
-        markdown_quote = "\n".join(("> " + line) for line in quote_content.get_text().split("\n"))
-        if quote_by is not None:
-            markdown_quote = f'> *{quote_by.get_text()}*\n' + markdown_quote
-        quote.replace_with(markdown_quote)
+
+    if blockquotes:
+        # Find how much space can be devoted to each quote -- divide any remaining
+        # space among them evenly
+        remaining_length = (max_length - text_length) // len(blockquotes)
+        for quote in blockquotes:
+            quote_by = quote.find('div', {'class': 'citey'})
+            quote_content = quote.find('div', {'class': 'quotey'})
+            if remaining_length > MIN_QUOTE_LENGTH:
+                # Recursively format inner quote text
+                # (base case is no quotes in which case this loop doesn't run)
+                _convert_formatting(quote_content, remaining_length)
+                markdown_quote = "\n".join(("> " + line) for line in quote_content.get_text().split("\n"))
+            else:
+                markdown_quote = f'> {SNIP_TEXT}'
+
+            # if quote has a cite, add it
+            if quote_by is not None:
+                markdown_quote = f'> **{quote_by.get_text()}**\n' + markdown_quote
+
+            # If multiple quotes next to each other, add a separating line
+            next_elem = quote.find_next_sibling()
+            if next_elem and next_elem.name and next_elem.name == 'blockquote':
+                markdown_quote += "\n"
+
+            quote.clear()
+            quote.insert(0, markdown_quote)
+
+    def rec_truncate(node, deficit):
+        # Recursive function to truncate *non-quoted* text.
+        # 'deficit' is how much we have to cut off. But we
+        # want to avoid slicing quotes in half when truncating,
+        # so we want to remove them wholesale if we run into
+        # them rather than just cutting the result of get_text()
+        # at the very end. Hence the semi-convoluted logic here.
+
+        # We iterate over the children of the node in reverse
+        # so we start cutting from the end
+        for child in reversed(list(node.children)):
+            if child.name and child.name == 'blockquote':
+                # Since we still have a deficit (i.e. we're still
+                # looping, so we still want to be cutting stuff off
+                # from the end), just remove the quote wholesale since
+                # it's going to be after the '...' in the post
+                child.clear()
+            elif child.string:
+                if len(child.string) < deficit:
+                    # Remove the whole child and reduce the deficit
+                    # by its length.
+                    deficit -= len(child.string)
+                    child.string.replace_with("")
+                else:
+                    # We reduced the deficit enough! Should fit
+                    # under the character limit now.
+                    child.string.replace_with(child.string[:-deficit] + TRUNCATE_TEXT)
+                    deficit = 0
+                    break
+            else:
+                # It's some kind of weird compound tag
+                deficit = rec_truncate(child, deficit)
+                if deficit <= 0: break
+
+        return deficit
+
+    if text_length > max_length:
+        rec_truncate(content, text_length - max_length)
 
     # Block spoilers stripped from preview
     block_spoilers = content.find_all('div', {'class': 'spoiler_container'})
@@ -115,10 +202,10 @@ def _parse_forum_post(data):
     body = soup.find('div', {'class': 'post-body'})
     content = body.find('div', {'class': 'message-content'})
 
-    _convert_formatting(content)
+    _convert_formatting(content, FORUM_PREVIEW_LENGTH)
 
-    # Trim the message text to a suitable preview length and strip extra whitespace.
-    text = content.get_text()[:FORUM_PREVIEW_LENGTH].strip()
+    # Convert to plaintext and strip extra whitespace.
+    text = content.get_text().strip()
 
     # We may have just stripped away part of an inline spoiler, so fix that if needed
     # (should be an even number of '||' delimiters)

--- a/forum_spy.py
+++ b/forum_spy.py
@@ -25,7 +25,7 @@ FORUM_SPY_REQUEST_HEADERS = {
     'Referer': 'https://forum.starmen.net/forum/spy',
     'User-Agent': 'discord-forum-spy-bot',
 }
-FORUM_PREVIEW_LENGTH = 500
+FORUM_PREVIEW_LENGTH = 250
 FORUM_COLOR_EVEN = int(0x010b17)
 FORUM_COLOR_ODD = int(0x001228)
 

--- a/forum_spy.py
+++ b/forum_spy.py
@@ -80,6 +80,9 @@ def _convert_formatting(content, max_length, nesting):
             elif child.string:
                 if child.string != "\n":
                     text_length += len(child.string)
+            # Skip children that are block spoilers
+            elif "spoiler_container" in child["class"]:
+                continue
             # Add non-string children's length recursively
             elif child is not node:
                 text_length += rec_textlength(child)
@@ -119,6 +122,11 @@ def _convert_formatting(content, max_length, nesting):
 
             quote.replace_with(markdown_quote)
 
+    # Block spoilers stripped from preview
+    block_spoilers = content.find_all('div', {'class': 'spoiler_container'})
+    for spoiler in block_spoilers:
+        spoiler.clear()
+
     def rec_truncate(node, deficit):
         # Recursive function to truncate *non-quoted* text.
         # 'deficit' is how much we have to cut off. But we
@@ -157,11 +165,6 @@ def _convert_formatting(content, max_length, nesting):
 
     if text_length > max_length:
         rec_truncate(content, text_length - max_length)
-
-    # Block spoilers stripped from preview
-    block_spoilers = content.find_all('div', {'class': 'spoiler_container'})
-    for spoiler in block_spoilers:
-        spoiler.clear()
 
     # Spoilerize inline spoilers
     inline_spoilers = content.find_all('span', {'class': 'inline_spoiler'})


### PR DESCRIPTION
I added quote formatting -- it puts ">" in front of quotes, as is the fashion on discord, and provides the name of the person being quoted (if one was provided).

Unfortunately Discord doesn't support nested quotes:
![argh why this sucks](https://i.imgur.com/wsSGo7a.png)

But it still tries its best. Maybe someday Discord will support quote nesting... And if we add support for more formatting in future, this recursive structure will ensure it gets passed on to the inside of the quote as well.

(If you add this, you should probably bump up the length posts get shortened to, since we don't want to have post previews that are just quotes, hah. For this screenshot I bumped up the length to 500 instead of 250; otherwise it just said "that's why i g")

