### PR TITLE
Block spoiler title and basic text formatting support

### DIFF
--- a/forum_spy.py
+++ b/forum_spy.py
@@ -58,7 +58,7 @@ def _get_username(user_profile):
     member = soup.find('a', {'class': 'member'})
     return member.string
 
-def _convert_formatting(content, max_length, nesting):
+def _format_quotes(content, max_length, nesting):
     # Handle blockquotes and spoiler blocks
 
     # Blockquotes: recursively formats inner quote content the same way
@@ -103,7 +103,7 @@ def _convert_formatting(content, max_length, nesting):
             if remaining_length > MIN_QUOTE_LENGTH:
                 # Recursively format inner quote text
                 # (base case is no quotes in which case this loop doesn't run)
-                _convert_formatting(quote_content, remaining_length, nesting + 1)
+                _format_quotes(quote_content, remaining_length, nesting + 1)
                 markdown_quote = "\n".join(("> " + line) for line in quote_content.get_text().split("\n"))
             else:
                 markdown_quote = f'> {SNIP_TEXT}'
@@ -163,6 +163,9 @@ def _convert_formatting(content, max_length, nesting):
 
     if text_length > max_length:
         rec_truncate(content, text_length - max_length)
+
+def _convert_formatting(content):
+    _format_quotes(content, FORUM_PREVIEW_LENGTH, 0)
 
     # Block spoilers replaced with title
     block_spoilers = content.find_all('div', {'class': 'spoiler_container'})
@@ -229,7 +232,7 @@ def _parse_forum_post(data):
     body = soup.find('div', {'class': 'post-body'})
     content = body.find('div', {'class': 'message-content'})
 
-    _convert_formatting(content, FORUM_PREVIEW_LENGTH, 0)
+    _convert_formatting(content)
 
     # Convert to plaintext and strip extra whitespace.
     text = content.get_text().strip()

--- a/forum_spy.py
+++ b/forum_spy.py
@@ -181,6 +181,22 @@ def _convert_formatting(content, max_length, nesting):
         new_spoiler = f'||{spoiler.get_text()}||'
         spoiler.replace_with(new_spoiler)
 
+    # Basic formatting
+    bolds = content.find_all('strong')
+    for bold in bolds:
+        if bold.get_text():
+            bold.replace_with(f'**{bold.get_text()}**')
+
+    italics = content.find_all('em')
+    for italic in italics:
+        if italic.get_text():
+            italic.replace_with(f'*{italic.get_text()}*')
+
+    strikethroughs = content.find_all('del')
+    for strikethrough in strikethroughs:
+        if strikethrough.get_text():
+            strikethrough.replace_with(f'~~{strikethrough.get_text()}~~')
+
 def _parse_forum_post(data):
     '''
     Pulls apart the AJAX data to find the bits of the forum post we want to display in


### PR DESCRIPTION
Adds support for *italic*, **bold**, ~~strikethrough~~, and also replaces block spoilers with **[Spoiler Title Here]**

![italic, spoiler, bold](https://i.imgur.com/iPC06C7.png)
![spoiler-with-title and strikethrough](https://i.imgur.com/hHnX04l.png)

i've mostly been mining the mafia forum for test posts because lots of good formatting in there >:)