### PR TITLE
Change "images, quotes and/or spoilers" text to just "images"

### DIFF
--- a/forum_spy.py
+++ b/forum_spy.py
@@ -279,7 +279,7 @@ def _parse_forum_post(data):  # pylint:disable=too-many-locals
         text += "||"
 
     if text == "":
-        text = "_[post contains only images, quotes and/or spoilers]_"
+        text = "_[post contains only images]_"
 
     post = {
         "id": post_id,


### PR DESCRIPTION
Correct phrasing of message: quotes and spoilers actually appear in spy text, so blank posts are just images

This has bugged me for a while. Not a functionality change, just changing this string.